### PR TITLE
Corrected INSTALL instructions.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -30,7 +30,6 @@ OBTAINING THE MODULE
 The latest release version of WWW::Shorten can be downloaded
 from any CPAN site:
 
-    http://www.cpan.org/modules/by-authors/id/S/SP/SPOON/
     https://metacpan.org/release/WWW-Shorten/
 
 Interim and development versions may also be available


### PR DESCRIPTION
The INSTALL section links to
  http://www.cpan.org/modules/by-authors/id/S/SP/SPOON/
as the place to download 'the latest release of WWW::Shorten'

but this is no longer true.

Of course the whole INSTALL file is a little bit huge!
