### PR TITLE
Accept http and https URLs for TinyURL

### DIFF
--- a/lib/WWW/Shorten/TinyURL.pm
+++ b/lib/WWW/Shorten/TinyURL.pm
@@ -41,7 +41,7 @@ sub makeashorterlink {
         }
         return undef;
     }
-    if ($resp->content =~ m!(\Qhttps://tinyurl.com/\E\w+)!x) {
+    if ($resp->content =~ m!(https?\Q://tinyurl.com/\E\w+)!x) {
         return $1;
     }
     return;
@@ -52,7 +52,7 @@ sub makealongerlink {
         or Carp::croak('No TinyURL key / URL passed to makealongerlink');
     $_error_message = '';
     $url = "https://tinyurl.com/$url"
-        unless $url =~ m!^https://!i;
+        unless $url =~ m!^https?://!i;
 
     # terrible, bad!  skip live testing for now.
     if ( $ENV{'WWW-SHORTEN-TESTING'} ) {


### PR DESCRIPTION
In Oct. 2020 tinyurl.com api-create.php started to return https://
shortened links #14.  For ~1 day tinyurl.com started returning http://
links again (#17).

Accept both http and https URLs.
