### PR TITLE
Add perl 5.40 (not for windows)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,11 +12,12 @@ jobs:
     strategy:
       matrix:
         perl-version:
+          - '5.40'
           - '5.38'
           - '5.18'
           - '5.10'
     container:
-      image: perl:${{ matrix.perl-version }}
+      image: perl:${{ matrix.perl-version }}-buster
     steps:
       - uses: actions/checkout@v4
       - name: perl -V

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         perl-version:
+          - '5.40'
           - '5.38'
           - '5.18'
           - '5.10'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,6 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         perl-version:
+          # - '5.40' Not yet for windows.
           - '5.38'
           - '5.14'
     steps:


### PR DESCRIPTION
This was my assignment from the [Pull Request Club](https://pullrequest.club). 
The obvious thing seemed to be include perl 5.40 - which I done.
Two  issues. 

1.  The windows version  - at least of the docker image doesn't exist for 5.40
2.  There is an issue with the Linux docker image, meaning instead of  perl-5.40 etc, I've used perl-5.40-buster. See [docker-perl issues 100]( https://github.com/Perl/docker-perl/issues/100). I suspect this can be reverted when the issue is resolved.